### PR TITLE
Fixed code snippet

### DIFF
--- a/doc_source/using-service-linked-roles.md
+++ b/doc_source/using-service-linked-roles.md
@@ -36,7 +36,6 @@ When you create an AWS Chatbot configuration, it creates the following policy fo
 
 ```
 {
-
     "Version": "2012-10-17",
     "Statement": [
         {
@@ -54,9 +53,9 @@ When you create an AWS Chatbot configuration, it creates the following policy fo
             "Effect": "Allow",
             "Action": [
               "logs:PutLogEvents",
-              "logs:CreateLogStream"
-              "logs:DescribeLogStreams"
-              "logs:CreateLogGroup"
+              "logs:CreateLogStream",
+              "logs:DescribeLogStreams",
+              "logs:CreateLogGroup",
               "logs:DescribeLogGroups"
             ],
             "Resource": "arn:aws:logs:*:*:log-group:/aws/chatbot/*"


### PR DESCRIPTION
Made the service-linked role policy valid JSON again by adding the requisite commas.

*Issue #, if available:* N/A

*Description of changes:*

JSON was broken in the relevant code snippet; it is now valid again.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
